### PR TITLE
wtype Alternative for KDE Plasma: dotool

### DIFF
--- a/README.org
+++ b/README.org
@@ -32,7 +32,7 @@ this script to see all available flags.
 ** Dependencies
 - [[http://www.passwordstore.org/][ZX2C4 pass]]
 - [[https://github.com/lbonn/rofi][rofi-wayland]]
-- wtype
+- [[https://git.sr.ht/~geb/dotool][dotool]]
 - wl-clipboard
 - [[https://fukuchi.org/works/qrencode/][qrencode]] (optional: for generating and displaying pass qrcode)
 - [[https://github.com/tadfisher/pass-otp][pass-otp]] (optional: for OTPs)

--- a/rofi-pass
+++ b/rofi-pass
@@ -259,19 +259,20 @@ _type() {
 
 	_wtype() {
 		sleep $wait              # delay before executing the typing sequence
-		wtype -d ${type_delay} - # delay before every key type
+		{ echo typedelay ${type_delay}; echo type $(cat); } | dotool # delay before every key type
 	}
+
 
 	autotype() {
 		# hold key for 50ms. Sometimes 'wtype -k "$1"' is too fast for programs
-		wpress_key() { wtype -P "$1" -s 50 -p "$1"; }
+		wpress_key() { { echo keydown "$1"; echo keydelay 50; echo keyup "$1"; } | dotool; }
 
 		for word in ${fields_map["$AUTOTYPE_FIELD"]}; do
 			case "$word" in
-				":tab") wpress_key Tab ;;
-				":space") wpress_key space ;;
+				":tab") wpress_key tab  ;;
+				":space") wpress_key space  ;;
 				":delay" | ":sleep") sleep "${delay}" ;;
-				":enter") wpress_key Return ;;
+				":enter") wpress_key enter  ;;
 				":otp" | "otp") printf '%s' "$(_get_otp "$passentry")" | _wtype ;;
 				"pass") printf '%s' "${fields_map[pass]}" | _wtype ;;
 				"path")
@@ -282,7 +283,7 @@ _type() {
 			esac
 		done
 
-		[[ ${auto_enter} == "true" ]] && wpress_key Return
+		[[ ${auto_enter} == "true" ]] && wpress_key enter
 	}
 
 	case "$field" in


### PR DESCRIPTION
Hi,

I don't want to actually merge my changes, but your issues board is closed and I just wanted to discuss.

When trying to reinstall `rofi-pass` on my new Wayland setup I came across your fork. For some reason unclear to me it seems `wtype` isn't supported in KDE Plasma. I found an alternative, which is `ydotool`. It is however quite slow to type password. Doing more research I've found [dotool](https://git.sr.ht/~geb/dotool) which has the advantage of running as a regular user (contrary to ydotool) and supports both X11 and Wayland.

If anyone wants to try it feel free to check my fork.