### PR TITLE
fix: suppress `command -v` output

### DIFF
--- a/rofi-pass
+++ b/rofi-pass
@@ -213,7 +213,7 @@ entry_menu() {
 		args+=(-kb-custom-8 "$kb_browse_url")
 	fi
 
-	if command -v qrencode; then
+	if command -v qrencode &> /dev/null; then
 		actions+=("$gen_qr")
 		args+=(-kb-custom-9 "$kb_qrcode")
 	fi
@@ -532,7 +532,7 @@ generate_qr() {
 	local passentry="$1"
 	local qrcode_path="$HOME/.cache/rofi/temp_pass_qr.png"
 
-	if ! command -v qrencode; then
+	if ! command -v qrencode &> /dev/null; then
 		printf '%s\n' "qrencode not found" | _rofi
 		assert_status $?
 		main_menu


### PR DESCRIPTION
When checking for the existence of the `qrencode` command, the path of `qrencode` is printed to the terminal. This is not the expected behavior and should be suppressed.